### PR TITLE
Fix config typo

### DIFF
--- a/configs/config.ini
+++ b/configs/config.ini
@@ -36,4 +36,4 @@ push_to_slack = false
 [EMAIL]
 push_to_email = true
 send_email = yifanli183313@gmail.com
-receve_emails = yifanli183313@gmail.com, lichili233@gmail.com, ztan36@asu.edu, anhdao@msu.edu
+receive_emails = yifanli183313@gmail.com, lichili233@gmail.com, ztan36@asu.edu, anhdao@msu.edu

--- a/main.py
+++ b/main.py
@@ -17,7 +17,6 @@ from parse_json_to_md import render_md_string
 from push_to_slack import push_to_slack
 from arxiv_scraper import EnhancedJSONEncoder
 
-from send_emails import send_email
 from datetime import datetime
 
 T = TypeVar("T")

--- a/parse_json_to_md.py
+++ b/parse_json_to_md.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
         email = config["EMAIL"]
         sender_email = email['send_email']        # sender email
         sender_password = os.environ.get("EMAIL_KEY") # sender passwd
-        recipient_email_list = email['receve_emails'].split(', ')
+        recipient_email_list = email['receive_emails'].split(', ')
 
         today_str = datetime.today().strftime("%Y_%m%d")
         subject = f"Daily ArXiv: {datetime.today().strftime('%m/%d/%Y')}"

--- a/send_emails.py
+++ b/send_emails.py
@@ -6,7 +6,6 @@ from email.mime.base import MIMEBase
 from email import encoders
 
 import os
-import re
 import json
 import configparser
 from datetime import datetime
@@ -29,7 +28,7 @@ def send_email(sender_email, sender_password, recipient_emails, subject, body, s
         # Create the email object
         message = MIMEMultipart()
         # message['From'] = Header(sender_email, 'utf-8')
-        message['From'] = f"Daily ArXiv <jackyfl@daily_arxiv.com>"
+        message['From'] = "Daily ArXiv <jackyfl@daily_arxiv.com>"
         # message['To'] = Header(", ".join(recipient_emails), 'utf-8')  # Join recipient emails with commas
         message['To'] = "Undisclosed Recipients"  # hideen the recipient emails
         message['Subject'] = Header(subject, 'utf-8')
@@ -85,7 +84,7 @@ if __name__ == "__main__":
             sender_email = email['send_email']        # sender email
             sender_password = os.environ.get("EMAIL_KEY") # sender passwd
             
-            recipient_email_list = email['receve_emails'].split(', ')
+            recipient_email_list = email['receive_emails'].split(', ')
             
             subject = f"Daily ArXiv: {datetime.today().strftime('%m/%d/%Y')}"
             paper_len = len(selected_papers)


### PR DESCRIPTION
## Summary
- rename `receve_emails` to `receive_emails` in `configs/config.ini`
- update references in email-related scripts
- remove unused import and unused function import

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_686ea301d0f4832f9164c842be941090